### PR TITLE
[bugfix] week/day formatting incompatible

### DIFF
--- a/lib/DateTime/Format/Duration/ISO8601.pm
+++ b/lib/DateTime/Format/Duration/ISO8601.pm
@@ -27,6 +27,7 @@ sub format_duration {
     );
 
     $S += $ns / 1_000_000_000;
+    $d += $w * 7;
 
     my $has_date = $y || $m || $w || $d;
     my $has_time = $H || $M || $S;
@@ -38,7 +39,6 @@ sub format_duration {
         "P",
         ($y, "Y") x !!$y,
         ($m, "M") x !!$m,
-        ($w, "W") x !!$w,
         ($d, "D") x !!$d,
         (
             "T",

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -13,6 +13,6 @@ my $d = DateTime::Format::Duration::ISO8601->new;
 is($d->format_duration(DateTime::Duration->new()), "PT0H0M0S");
 is($d->format_duration(DateTime::Duration->new(years=>1)), "P1Y");
 is($d->format_duration(DateTime::Duration->new(hours=>2)), "PT2H");
-is($d->format_duration(DateTime::Duration->new(years=>1, months=>2, weeks=>2, days=>7+4, hours=>5, minutes=>6, seconds=>7, nanoseconds=>800_000_000)), "P1Y2M3W4DT5H6M7.8S");
+is($d->format_duration(DateTime::Duration->new(years=>1, months=>2, weeks=>2, days=>7+4, hours=>5, minutes=>6, seconds=>7, nanoseconds=>800_000_000)), "P1Y2M25DT5H6M7.8S");
 
 done_testing;


### PR DESCRIPTION
ISO 8601 duration strings cannot mix the PnYnMnDTnHnMnS and PnW styles, this prevents at least the creation of invalid strings. Perhaps Dt::Dur objects that are purely `days % 7` could be serialized as such.